### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Pass: snorby
 	* Mac OSX:
 	
 		`brew install imagemagick`
+		`brew install mysql`
 
 	* Linux:
 	


### PR DESCRIPTION
In order to install the bundle mysql is required. If not, `which mysql_config` returns nothing, which fails the install of `do_mysql`
